### PR TITLE
Updated upper version limits

### DIFF
--- a/Rebus.Microsoft.Extensions.Configuration/Rebus.Microsoft.Extensions.Configuration.csproj
+++ b/Rebus.Microsoft.Extensions.Configuration/Rebus.Microsoft.Extensions.Configuration.csproj
@@ -28,7 +28,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="rebus" Version="8.6.1" />
-		<PackageReference Include="microsoft.extensions.configuration" Version="[6.0.0, 10)" />
-		<PackageReference Include="microsoft.extensions.configuration.binder" Version="[6.0.0, 10)" />
+		<PackageReference Include="microsoft.extensions.configuration" Version="[6.0.0, 11)" />
+		<PackageReference Include="microsoft.extensions.configuration.binder" Version="[6.0.0, 11)" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updated upper version limits of microsoft packages to 11 ##4

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
